### PR TITLE
don't overwrite existing module files. fix #87

### DIFF
--- a/R/AddModules.R
+++ b/R/AddModules.R
@@ -73,7 +73,7 @@ AddModules <- function(
             recursive = TRUE,
             full.names = TRUE
         )
-
+   
         #Also get file names for update to global.R below.
         vCurrentFiles <- list.files(
             strSrcDirectory,
@@ -84,7 +84,13 @@ AddModules <- function(
         vModuleFiles <- c(vModuleFiles,vCurrentFiles)
 
         if(length(vCurrentPaths)>0){
-            file.copy(from=vCurrentPaths, to=strDestDirectory)
+            vDestPaths <- paste0(strDestDirectory,"/",vCurrentFiles)
+            vDestExists <- vCurrentFiles[file.exists(vDestPaths)] 
+            if(length(vDestExists > 0 )){
+                print("The following file(s) already exist in your app and will not be replaced; This may cause unexpected behavior.  You can delete the file(s) and rerun this command, or manually edit the existing file.")
+                print(paste(vDestExists, collapse=", "))
+            }
+            file.copy(from=vCurrentPaths, to=strDestDirectory, overwrite=FALSE)
         }else{
             #If no matching files are found create a new module using a template
             CreateModule(

--- a/R/createModule.R
+++ b/R/createModule.R
@@ -31,13 +31,26 @@ CreateModule <- function(
     #Merge in custom paramaters (if any)
     parameters <- c(list(MODULE_ID=strModuleID),lCustomParameters)
 
-    #Create UI Module
+    # Test for existing files
     strUIPath <- paste0(strDestDirectory,"/mod_",strModuleID,"UI.R")
-    strUI  <-whisker.render(strUITemplate, data=parameters)
-    writeLines( strUI, con = strUIPath)
+    strServerPath <- paste0(strDestDirectory,"/mod_",strModuleID,"Server.R")
+    vDestPaths <- c(strUIPath, strServerPath)
+    vCurrentFiles<-c(paste0("mod_",strModuleID,"UI.R"),paste0("mod_",strModuleID,"Server.R"))
+    vDestExists <- vCurrentFiles[file.exists(vDestPaths)] 
+    if(length(vDestExists > 0 )){
+        print(paste0("Caution: The following file(s) for the '",strModuleID, "' module already exist in your app and will not be replaced; This may cause unexpected behavior.  You can delete the file(s) and rerun this command, or manually edit the existing file."))
+        print(paste("File(s) not copied:", paste(vDestExists, collapse=", ")))
+    }
+
+    #Create UI Module
+    if(!file.exists(strUIPath)){
+        strUI  <-whisker.render(strUITemplate, data=parameters)
+        writeLines( strUI, con = strUIPath)
+    }
 
     #Create Server Module
-    strServerPath <- paste0(strDestDirectory,"/mod_",strModuleID,"Server.R")
-    strServer  <-whisker.render(strServerTemplate, data=parameters)
-    writeLines( strServer, con = strServerPath)
+    if(!file.exists(strServerPath)){
+        strServer  <-whisker.render(strServerTemplate, data=parameters)
+        writeLines( strServer, con = strServerPath)
+    }
 }


### PR DESCRIPTION
# Summary 

`AddModules()` and `CreateModule()` now check for existing module files before create/copying files from PREP templates. Those functions were the only ones writing to disk, so this also trickles down to `CreateApp()`, `AddModule()` and `AddTab()` which call those core functions. Fixes #87 

# Test Code

Create an app and then try creating some duplicate modules using the functions above. Here's a chunk of my testing to demo expected behavior. 
![image](https://user-images.githubusercontent.com/3680095/95471971-7a5ed100-0950-11eb-86e2-d71ff8316240.png)
